### PR TITLE
Update TCL synthesis scripts for VPR

### DIFF
--- a/fabulous/synth/synth_fabulous.tcl
+++ b/fabulous/synth/synth_fabulous.tcl
@@ -3,6 +3,7 @@
 
 set LUT_K 4
 if {$argc > 0} { set LUT_K [lindex $argv 0] }
+set for_vpr [expr {[file extension [lindex $argv 2]] == ".blif"}]
 yosys read_verilog -lib [file dirname [file normalize $argv0]]/prims.v
 yosys hierarchy -check -top [lindex $argv 1]
 yosys proc
@@ -18,13 +19,13 @@ yosys dfflegalize -cell \$_DFF_P_ 0 -cell \$_DLATCH_?_ x
 yosys techmap -map [file dirname [file normalize $argv0]]/latches_map.v
 yosys abc -lut $LUT_K -dress
 yosys clean
-yosys techmap -D LUT_K=$LUT_K -map [file dirname [file normalize $argv0]]/cells_map.v
+if {!$for_vpr} {yosys techmap -D LUT_K=$LUT_K -map [file dirname [file normalize $argv0]]/cells_map.v}
 yosys clean
 yosys hierarchy -check
 yosys stat
 
 if {$argc > 1} {
-        if {[file extension [lindex $argv 2]] == ".blif"} { 
+        if {$for_vpr} { 
                 yosys write_blif [lindex $argv 2] 
         } else { 
                 yosys write_json [lindex $argv 2] 

--- a/fabulous/synth/synth_fabulous.tcl
+++ b/fabulous/synth/synth_fabulous.tcl
@@ -23,4 +23,10 @@ yosys clean
 yosys hierarchy -check
 yosys stat
 
-if {$argc > 1} { yosys write_json [lindex $argv 2] }
+if {$argc > 1} {
+        if {[file extension [lindex $argv 2]] == ".blif"} { 
+                yosys write_blif [lindex $argv 2] 
+        } else { 
+                yosys write_json [lindex $argv 2] 
+        }
+}

--- a/fabulous/synth/synth_fabulous_dffesr.tcl
+++ b/fabulous/synth/synth_fabulous_dffesr.tcl
@@ -3,6 +3,7 @@
 
 set LUT_K 4
 if {$argc > 0} { set LUT_K [lindex $argv 0] }
+set for_vpr [expr {[file extension [lindex $argv 2]] == ".blif"}]
 yosys read_verilog -lib [file dirname [file normalize $argv0]]/prims_ff.v
 yosys hierarchy -check -top [lindex $argv 1]
 yosys proc
@@ -22,9 +23,15 @@ yosys simplemap
 yosys techmap -map [file dirname [file normalize $argv0]]/latches_map.v
 yosys abc -lut $LUT_K -dress
 yosys clean
-yosys techmap -D LUT_K=$LUT_K -map [file dirname [file normalize $argv0]]/cells_map_ff.v
+if {!$for_vpr} {yosys techmap -D LUT_K=$LUT_K -map [file dirname [file normalize $argv0]]/cells_map_ff.v}
 yosys clean
 yosys hierarchy -check
 yosys stat
 
-if {$argc > 1} { yosys write_json [lindex $argv 2] }
+if {$argc > 1} {
+        if {$for_vpr} { 
+                yosys write_blif [lindex $argv 2] 
+        } else { 
+                yosys write_json [lindex $argv 2] 
+        }
+}


### PR DESCRIPTION
This PR updates the TCL scripts used for synthesis with Yosys so that they can also be used for synthesis with the VPR flow. The synthesis scripts now check the file extension of the provided output file. If it is '.blif', then the techmapping of LUTs is skipped (as VPR handles BLIF .names models directly) and BLIF is output - otherwise, LUTs are techmapped and JSON is produced.