### PR TITLE
Remove flatten pass

### DIFF
--- a/fabulous/synth/synth_fabulous.tcl
+++ b/fabulous/synth/synth_fabulous.tcl
@@ -7,7 +7,7 @@ set for_vpr [expr {[file extension [lindex $argv 2]] == ".blif"}]
 yosys read_verilog -lib [file dirname [file normalize $argv0]]/prims.v
 yosys hierarchy -check -top [lindex $argv 1]
 yosys proc
-yosys flatten
+#yosys flatten
 yosys tribuf -logic
 yosys deminout
 yosys synth -run coarse

--- a/fabulous/synth/synth_fabulous_dffesr.tcl
+++ b/fabulous/synth/synth_fabulous_dffesr.tcl
@@ -7,7 +7,7 @@ set for_vpr [expr {[file extension [lindex $argv 2]] == ".blif"}]
 yosys read_verilog -lib [file dirname [file normalize $argv0]]/prims_ff.v
 yosys hierarchy -check -top [lindex $argv 1]
 yosys proc
-yosys flatten
+#yosys flatten
 yosys tribuf -logic
 yosys deminout
 yosys synth -run coarse


### PR DESCRIPTION
It was recently flagged that the synthesis script has an issue when executing on designs containing submodules, as it synthesises only top-level models (although JSON output contains references to the source files of the other modules). It looks like removing the flatten part from the script fixes this issue and shouldn't change the correctness as it appears to just be an optimisation/representation change pass.